### PR TITLE
Implement Twig_Extension_GlobalsInterface

### DIFF
--- a/Twig/ShariffExtension.php
+++ b/Twig/ShariffExtension.php
@@ -11,7 +11,7 @@ namespace Valiton\Bundle\ShariffBundle\Twig;
 
 use Valiton\Bundle\ShariffBundle\ShariffConfig;
 
-class ShariffExtension extends \Twig_Extension
+class ShariffExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
     protected $shariffConfig;
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=5.3.0",
         "heise/shariff": "~1.0",
         "symfony/framework-bundle": ">=2.1.0",
-        "friendsofsymfony/rest-bundle": "~1.2"
+        "friendsofsymfony/rest-bundle": "~1.2",
+        "twig/twig": "~1.23|~2.0"
     },
     "autoload": {
         "psr-0": { "Valiton\\Bundle\\ShariffBundle": "" }


### PR DESCRIPTION
Due to the following deprecation log message that occurs using the ShariffExtension in Symfony v2.8 scope (and Twig 1.23.) it would be great if you'd offer a twig 1.23. compatible release of your package.

Deprecation log message:
Defining the getGlobals() method in the "shariff" extension without explicitly implementing Twig_Extension_GlobalsInterface is deprecated since version 1.23.
