### PR TITLE
Modifications for handling http/https count losses

### DIFF
--- a/Controller/ShariffController.php
+++ b/Controller/ShariffController.php
@@ -19,19 +19,35 @@ class ShariffController
     /** @var  ShariffServiceInterface */
     protected $shariffService;
 
+    /** @var ShariffConfig */
+    protected $config;
+
     /** @var  ViewHandlerInterface */
     protected $viewHandler;
 
-    public function __construct(ShariffServiceInterface $shariffService, ViewHandlerInterface $viewHandler)
+    public function __construct(ShariffServiceInterface $shariffService, ShariffConfig $config, ViewHandlerInterface $viewHandler)
     {
         $this->shariffService = $shariffService;
         $this->viewHandler = $viewHandler;
+        $this->config = $config;
     }
 
 
     public function get(Request $request)
     {
-        $result = $this->shariffService->get($request->query->get('url'));
+        $url = $request->query->get('url');
+        $forceProtocol = $this->config->getForceProtocol();
+
+        if(!is_null($forceProtocol)){
+            if($forceProtocol === "https"){
+                $url = str_replace('http://','https://',$url);
+            }
+            if($forceProtocol === "http"){
+                $url = str_replace('https://','http://',$url);
+            }
+        }
+
+        $result = $this->shariffService->get($url);
 
         $view = View::create($result);
         $view->setFormat('json');

--- a/Controller/ShariffController.php
+++ b/Controller/ShariffController.php
@@ -38,12 +38,12 @@ class ShariffController
         $url = $request->query->get('url');
         $forceProtocol = $this->config->getForceProtocol();
 
-        if(!is_null($forceProtocol)){
-            if($forceProtocol === "https"){
-                $url = str_replace('http://','https://',$url);
+        if (!is_null($forceProtocol)) {
+            if ($forceProtocol === "https") {
+                $url = str_replace('http://', 'https://', $url);
             }
-            if($forceProtocol === "http"){
-                $url = str_replace('https://','http://',$url);
+            if ($forceProtocol === "http") {
+                $url = str_replace('https://', 'http://', $url);
             }
         }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('domain')->isRequired()->end()
+                ->scalarNode('force_protocol')->defaultNull()->end()
                 ->arrayNode('cache')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/ValitonShariffExtension.php
+++ b/DependencyInjection/ValitonShariffExtension.php
@@ -23,6 +23,7 @@ class ValitonShariffExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('valiton_shariff.shariff_config.domain', $config['domain']);
+        $container->setParameter('valiton_shariff.shariff_config.force_protocol', $config['force_protocol']);
         $container->setParameter('valiton_shariff.shariff_config.cache', $config['cache']);
         $container->setParameter('valiton_shariff.shariff_config.services', $config['services']);
         $container->setParameter('valiton_shariff.shariff_config.client', $config['client']);

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Configure the bundle according to your needs, full config example:
 ```
 valiton_shariff:
     domain: '<your-domain>' 
-    force_protocol: ~
+    force_protocol: ~ # http or https
     cache:
         cacheDir: '%kernel.cache_dir%'   
         ttl: 3600

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Configure the bundle according to your needs, full config example:
 ```
 valiton_shariff:
     domain: '<your-domain>' 
+    force_protocol: ~
     cache:
         cacheDir: '%kernel.cache_dir%'   
         ttl: 3600

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="valiton_shariff_get" pattern="/get">
+    <route id="valiton_shariff_get" path="/get">
         <default key="_controller">valiton_shariff.shariff_controller:get</default>
         <option key="expose">true</option>
     </route>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,6 +14,7 @@
     <services>
         <service id="valiton_shariff.shariff_config" class="%valiton_shariff.shariff_config.class%">
             <argument>%valiton_shariff.shariff_config.domain%</argument>
+            <argument>%valiton_shariff.shariff_config.force_protocol%</argument>
             <argument>%valiton_shariff.shariff_config.services%</argument>
             <argument>%valiton_shariff.shariff_config.cache%</argument>
             <argument>%valiton_shariff.shariff_config.client%</argument>
@@ -25,6 +26,7 @@
 
         <service id="valiton_shariff.shariff_controller" class="%valiton_shariff.shariff_controller.class%">
             <argument type="service" id="valiton_shariff.shariff_service"/>
+            <argument type="service" id="valiton_shariff.shariff_config"/>
             <argument type="service" id="fos_rest.view_handler"/>
         </service>
 

--- a/ShariffConfig.php
+++ b/ShariffConfig.php
@@ -15,6 +15,9 @@ class ShariffConfig
     protected $domain;
 
     /** @var string */
+    protected $force_protocol;
+
+    /** @var string */
     protected $cacheDir;
 
     /** @var int */
@@ -35,9 +38,10 @@ class ShariffConfig
     /** @var array */
     protected $client;
 
-    public function __construct($domain, $services, $cache, $client)
+    public function __construct($domain, $force_protocol, $services, $cache, $client)
     {
         $this->domain = $domain;
+        $this->force_protocol = $force_protocol;
         $this->services = array_keys($services);
         $this->cacheTtl = $cache['ttl'];
         $this->cacheDir = isset($cache['cacheDir']) ? $cache['cacheDir'] : null;
@@ -102,6 +106,22 @@ class ShariffConfig
     }
 
     /**
+     * @return string
+     */
+    public function getForceProtocol()
+    {
+        return $this->force_protocol;
+    }
+
+    /**
+     * @param string $force_protocol
+     */
+    public function setForceProtocol($force_protocol)
+    {
+        $this->force_protocol = $force_protocol;
+    }
+
+    /**
      * @param array $services
      */
     public function setServices($services)
@@ -153,6 +173,7 @@ class ShariffConfig
     {
         $result = array();
         $result['domain'] = $this->domain;
+        $result['force_protocol'] = $this->force_protocol;
         $result['services'] = $this->services;
         $result = array_merge($result, $this->serviceConfig);
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=5.3.0",
         "heise/shariff": "~1.0",
         "symfony/framework-bundle": ">=2.1.0",
-        "friendsofsymfony/rest-bundle": "~1.2"
+        "friendsofsymfony/rest-bundle": "~1.2",
+        "twig/twig": "~1.23|~2.0"
     },
     "autoload": {
         "psr-0": { "Valiton\\Bundle\\ShariffBundle": "" }


### PR DESCRIPTION
Due to the fact that facebook and co are considering urls with http and https to be different you will lose social counts after switching the whole website from http to https mode.

To handle this I implemented a new configuration param called "force_protocol" which may be set "http" or "https" (default: null). If one of those two possible values is set every request url will be modified on the fly before calling the shariff service and further the social media api of facebook, google and co.

If force_protocol is set null (~ tilde) no modification will be done to the requests url.
